### PR TITLE
add events command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ If you use TLS/SSL/https without valid certificate you can use the flag
 `--ignore_cert_errors` to suppress the errors. This is considered very insecure.
 
 ### JSON output
-`stc json_dump` prints the same folder and device info as the default command, but in JSON format for more reliable use in scripts. `jq` is a great option for processing output. 
+
+`stc json_dump` prints the same folder and device info as the default command, but in JSON format for more reliable use in scripts. `jq` is a great option for processing output.
 
 Examples
 
@@ -74,24 +75,28 @@ Display the device with the greatest count of uploaded bytes:
   --homedir             - Path of Syncthing home directory, if specified stc
                           will try to find apikey and target from config.xml
   --ignore_cert_errors  - Ignore cert errors while using https/SSL/TLS
+  --since               - Limit of items to return when returning lists
+  --limit               - ID of item to start from when returning lists
 ```
 
 ## Arguments / Commands
 
 ```text
-  log           - print syncthing 'recent' log
-  restart       - restart syncthing daemon
-  shutdown      - shutdown syncthing daemon
-  errors        - print errors visible in web UI
-  clear_errors  - clear errors in the web UI
-  post_error    - posts a custom error message in the web UI
-  folder_errors - prints folder errors from scan or pull
-  id            - print ID of this node
-  reset_db      - reset the database / file index
-  rescan        - rescan a folder or 'all'
-  override      - override remote changed for a send-only folder (OoSync)
-  revert        - revert local changes for a receive-only folder (LocAdds)
-  json_dump     - prints a json object with device and folder info, for easier parsing in scripts 
+  log            - print syncthing 'recent' log
+  restart        - restart syncthing daemon
+  shutdown       - shutdown syncthing daemon
+  errors         - print errors visible in web UI
+  clear_errors   - clear errors in the web UI
+  post_error     - posts a custom error message in the web UI
+  folder_errors  - prints folder errors from scan or pull
+  id             - print ID of this node
+  reset_db       - reset the database / file index
+  rescan         - rescan a folder or 'all'
+  override       - override remote changed for a send-only folder (OoSync)
+  revert         - revert local changes for a receive-only folder (LocAdds)
+  events [types] - prints a json list of latest events, [types] is a comma-delimited list of events
+                   see https://docs.syncthing.net/dev/events.html#event-types for a list of event types
+  json_dump      - prints a json object with device and folder info, for easier parsing in scripts
 ```
 
 ## Download binaries
@@ -100,5 +105,5 @@ See [Releases](https://github.com/tenox7/stc/releases)
 
 ## Legal
 
-* Copyright 2024 Antoni Sawicki et al
-* Licensed under Apache 2.0
+- Copyright 2024 Antoni Sawicki et al
+- Licensed under Apache 2.0

--- a/README.md
+++ b/README.md
@@ -99,7 +99,11 @@ Display the device with the greatest count of uploaded bytes:
   json_dump      - prints a json object with device and folder info, for easier parsing in scripts
 ```
 
-## Download binaries
+## Installation
+
+`go install github.com/tenox7/stc@latest`
+
+### Download binaries
 
 See [Releases](https://github.com/tenox7/stc/releases)
 

--- a/api/api.go
+++ b/api/api.go
@@ -44,7 +44,7 @@ type SysConnections struct {
 type SysStatus struct {
 	MyID   string `json:"myID"`
 	Uptime int64  `json:"uptime"`
-	Ram uint64 `json:"sys"`
+	Ram    uint64 `json:"sys"`
 }
 
 type SysVersion struct {
@@ -353,4 +353,20 @@ func Revert(folderID string) error {
 		return apiError(r.Status())
 	}
 	return nil
+}
+
+func Events(event_types string, limit int, since int) (string, error) {
+	r, err := c.R().
+		SetQueryString("events=" + event_types).
+		SetQueryString(fmt.Sprintf("since=%d", since)).
+		SetQueryString(fmt.Sprintf("limit=%d", limit)).
+		Get("events")
+	if err != nil {
+		return "", apiError(err)
+	}
+	if r.IsError() {
+		return "", apiError(r.Status())
+	}
+
+	return r.String(), nil
 }

--- a/hlp.go
+++ b/hlp.go
@@ -15,21 +15,23 @@ func usage() {
 	fmt.Fprintf(o, "stc [flags] [commands]\n\nflags:\n")
 	flag.PrintDefaults()
 	fmt.Fprintf(o, "\ncommands:\n"+
-		"  log           - print syncthing 'recent' log\n"+
-		"  restart       - restart syncthing daemon\n"+
-		"  shutdown      - shutdown syncthing daemon\n"+
-		"  errors        - print errors visible in web UI\n"+
-		"  clear_errors  - clear errors in the web UI\n"+
-		"  post_error    - posts a custom error message in the web UI\n"+
-		"  folder_errors - prints folder errors from scan or pull\n"+
-		"  folder_pause  - pause specified folder\n"+
-		"  folder_resume - unpause specified folder\n"+
-		"  id            - print ID of this node\n"+
-		"  reset_db      - reset the database / file index\n"+
-		"  rescan        - rescan a folder or 'all'\n"+
-		"  override      - override remote changed for a send-only folder (OoSync)\n"+
-		"  revert        - revert local changes for a receive-only folder (LocAdds)\n"+
-		"  json_dump     - prints a json object with device and folder info, for easier parsing in scripts\n",
+		"  log            - print syncthing 'recent' log\n"+
+		"  restart        - restart syncthing daemon\n"+
+		"  shutdown       - shutdown syncthing daemon\n"+
+		"  errors         - print errors visible in web UI\n"+
+		"  clear_errors   - clear errors in the web UI\n"+
+		"  post_error     - posts a custom error message in the web UI\n"+
+		"  folder_errors  - prints folder errors from scan or pull\n"+
+		"  folder_pause   - pause specified folder\n"+
+		"  folder_resume  - unpause specified folder\n"+
+		"  id             - print ID of this node\n"+
+		"  reset_db       - reset the database / file index\n"+
+		"  rescan         - rescan a folder or 'all'\n"+
+		"  override       - override remote changed for a send-only folder (OoSync)\n"+
+		"  revert         - revert local changes for a receive-only folder (LocAdds)\n"+
+		"  events [types] - prints a json list of latest events, [types] is a comma-delimited list of events\n"+
+		"                   see https://docs.syncthing.net/dev/events.html#event-types for a list of event types\n"+
+		"  json_dump      - prints a json object with device and folder info, for easier parsing in scripts\n",
 	)
 }
 

--- a/stc.go
+++ b/stc.go
@@ -20,6 +20,8 @@ var (
 	apiKey  = flag.String("apikey", "", "Syncthing API Key")
 	target  = flag.String("target", "", "Syncthing Target URL")
 	homeDir = flag.String("homedir", "", "Syncthing Home Directory, used to get API Key and Target")
+	limit   = flag.Int("limit", -1, "Limit of items to return when returning lists")
+	since   = flag.Int("since", 0, "ID of item to start from when returning lists")
 	igCert  = flag.Bool("ignore_cert_errors", false, "ignore https/ssl/tls cert errors")
 	verFlag = flag.Bool("version", false, "print version")
 	GitTag  string
@@ -349,6 +351,15 @@ func folderErrors(fName string) error {
 	return nil
 }
 
+func events(event_types string, limit int, since int) error {
+	events, err := api.Events(event_types, limit, since)
+	if err != nil {
+		return err
+	}
+	fmt.Println(events)
+	return nil
+}
+
 func main() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	flag.Usage = usage
@@ -401,6 +412,8 @@ func main() {
 		err = api.PauseFolder(flag.Arg(1), true)
 	case "folder_resume":
 		err = api.PauseFolder(flag.Arg(1), false)
+	case "events":
+		err = events(flag.Arg(1), *limit, *since)
 	case "json_dump":
 		err = dumpDashAsJson()
 	default:


### PR DESCRIPTION
Adds an `event` subcommand.

For example `stc --limit 1 events LocalChangeDetected,RemoteChangeDetected`

```json
[
  {
    "id": 4901,
    "globalID": 48353,
    "time": "2024-10-10T21:03:58.979554558-03:00",
    "type": "LocalChangeDetected",
    "data": {
      "action": "modified",
      "folder": "123",
      "folderID": "123",
      "label": "SyncMisc",
      "modifiedBy": "ABC",
      "path": "config/atuin/tombh-db/history.db-wal",
      "type": "file"
    }
  }
]
```