### PR TITLE
extends findCfgFile to check for Scoop and Syncthing Tray paths

### DIFF
--- a/hlp.go
+++ b/hlp.go
@@ -79,6 +79,28 @@ func findCfgFile(homeDir string) (string, error) {
 		return cfgFile, nil
 	}
 
+	//try appdata/local/syncthing (windows)
+	userCfgDir, err = os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	homeDir = filepath.Join(userCfgDir, "syncthing")
+	cfgFile, err = getCfgFile(homeDir)
+	if err == nil {
+		return cfgFile, nil
+	}
+
+	//try scoop dir (windows)
+	homeDir, err = os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	newStateDir = filepath.Join(homeDir, "scoop", "persist", "syncthing", "config")
+	cfgFile, err = getCfgFile(newStateDir)
+	if err == nil {
+		return cfgFile, nil
+	}
+
 	// fall back to path of argv[0]
 	homeDir, err = os.Executable()
 	if err != nil {


### PR DESCRIPTION
This PR extends `findCfgFile` to check extra paths that are used when syncthing is installed through either Scoop or through [Syncthing Tray](https://martchus.github.io/doc/syncthingtray/README.html#does-this-launch-or-bundle-syncthing-itself-what-about-my-existing-syncthing-installation).

